### PR TITLE
Fix missing return annotation for table.newarray

### DIFF
--- a/kahlua.lua
+++ b/kahlua.lua
@@ -47,6 +47,7 @@ function table.isempty(table) end
 function table.wipe(table) end
 
 ---@overload fun(table: table): table
+---@param ... any
 ---@return table
 function table.newarray(...) end
 

--- a/kahlua.lua
+++ b/kahlua.lua
@@ -47,7 +47,7 @@ function table.isempty(table) end
 function table.wipe(table) end
 
 ---@overload fun(table: table): table
----@overload fun(...: any): table
+---@return table
 function table.newarray(...) end
 
 


### PR DESCRIPTION
This fixes a bug where the language server believes the function can return nil, requiring a narrowing cast to use the array without warnings