### PR TITLE
Add Rosetta path argument

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ const annotateFiles = async (options: AnnotateArgs) => {
     const rosetta = new Rosetta()
 
     try {
-        rosetta.load('assets/rosetta')
+        rosetta.load(options.rosetta)
     } catch (e) {
         console.log(`Failed to load rosetta; creating fallback annotations. ${e}`)
     }
@@ -103,6 +103,7 @@ yargs(hideBin(process.argv))
                 .option('verbose', { type: 'boolean', alias: 'v' })
                 .option('include-kahlua', { type: 'boolean', alias: 'k' })
                 .option('strict-fields', { type: 'boolean' })
+                .option('rosetta', {type : 'string', default: 'assets/rosetta' })
                 .check(args => {
                     const inDir = path.resolve(args.in)
                     if (!fs.existsSync(inDir)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,4 +4,5 @@ export interface AnnotateArgs {
     verbose?: boolean
     ['include-kahlua']?: boolean
     ['strict-fields']?: boolean
+    rosetta: string
 }


### PR DESCRIPTION
Adds a ``--rosetta`` argument to specify the base directory of the Rosetta data to use for documentation, rather than the currently hardcoded path. The argument is optional and defaults to the original path.